### PR TITLE
Add partial code comments

### DIFF
--- a/c2nl/decoders/transformer.py
+++ b/c2nl/decoders/transformer.py
@@ -91,6 +91,7 @@ class TransformerDecoderLayer(nn.Module):
                                      attn_type="self")
         query_norm = self.layer_norm(self.drop(query) + inputs)
 
+        # changed : Source Code Self-Attention
         mid, attn, coverage = self.context_attn(memory_bank,
                                                 memory_bank,
                                                 query_norm,
@@ -101,6 +102,7 @@ class TransformerDecoderLayer(nn.Module):
                                                 coverage=coverage)
         mid_norm = self.layer_norm_1(self.drop(mid) + query_norm)
 
+        # changed : Method Summary Self-Attention
         mid, attn, coverage = self.ast_attn(ast_memory,
                                             ast_memory,
                                             mid_norm,

--- a/c2nl/encoders/transformer.py
+++ b/c2nl/encoders/transformer.py
@@ -97,6 +97,7 @@ class TransformerEncoderLayer(nn.Module):
                                                        mask=mask, attn_type="self")
             out = self.layer_norm(self.dropout(context) + inputs)
         else:
+            # changed : Cross-Attention
             context, attn_per_head, _ = self.attention(inputs, inputs, inputs1,
                                                        mask=mask, attn_type="self")
             out = self.layer_norm(self.dropout(context) + inputs1)

--- a/c2nl/models/transformer.py
+++ b/c2nl/models/transformer.py
@@ -119,7 +119,8 @@ class Embedder(nn.Module):
                     pos_enc = pos_enc.cuda()
                 pos_rep = self.src_pos_embeddings(pos_enc)
                 word_rep = word_rep + pos_rep
-            
+
+            # changed ：embedding processing for ast_sequence
             if self.use_ast_node:
                 ast_rep = self.ast_node_embeddings(ast_sequence.unsqueeze(2))
                 ast_pos_enc = torch.arange(start=0,
@@ -451,7 +452,8 @@ class Transformer(nn.Module):
 #         code_rep = input_emb1.permute(0, 2, 3, 1).contiguous().view(-1, len // 2, self.embedder.enc_input_size)
 
         code_rep, code_len = self.convolution(code_rep, code_len)
-        
+
+        # changed：implementation for the shared encoder
         memory_bank, layer_wise_outputs = self.encoder(code_rep, code_len)  # B x seq_len x h
         
         ast_memory, ast_layer_wise_outputs = self.encoder(ast_rep, ast_len)

--- a/c2nl/modules/multi_head_attn.py
+++ b/c2nl/modules/multi_head_attn.py
@@ -145,7 +145,7 @@ class MultiHeadedAttention(nn.Module):
                         dim=2)
                 layer_cache["self_keys"] = key
                 layer_cache["self_values"] = value
-
+            # changed : handling for different types of multi-head attention
             elif attn_type == "context":
                 query = shape(self.query(query), self.d_k)
                 if layer_cache["memory_keys"] is None:
@@ -156,7 +156,7 @@ class MultiHeadedAttention(nn.Module):
                                  layer_cache["memory_values"]
                 layer_cache["memory_keys"] = key
                 layer_cache["memory_values"] = value
-                
+
             elif attn_type == "ast":
                 query = shape(self.query(query), self.d_k)
                 if layer_cache["ast_keys"] is None:


### PR DESCRIPTION
## 代码主要修改

### c2nl/decoders/transformer.py

TransformerDecoderLayer内新增context_attn、method_attn、ast_attn等多个多头注意力层，主要是为了实现论文中解码器部分的结构

### c2nl/encoders/transformmer.py

新增encoder交叉注意力的代码实现逻辑

### c2nl/models/transformer.py

1. 新增ast_sequence、method_sequence等的embedding处理代码

2. 新增共享编码器的代码实现

### c2nl/modules/multi_head_attn.py

新增对不同类型多头注意力的处理